### PR TITLE
fix: update expr needed to get repo link

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -161,7 +161,12 @@ func ParseRepos(r io.Reader) ([]Repository, error) {
 	for _, article := range articleList {
 		repo = &Repository{}
 		// Href, RepoName
-		hrefPath := htmlquery.SelectAttr(htmlquery.FindOne(article, "/h1/a"), "href")
+		repoLinkNode := htmlquery.FindOne(article, "/h2/a")
+		if repoLinkNode == nil {
+			return nil, fmt.Errorf("repository link cannot be found")
+		}
+
+		hrefPath := htmlquery.SelectAttr(repoLinkNode, "href")
 		repo.Href = path.Join(githubURL, hrefPath)
 		repoName := strings.Split(hrefPath, "/")
 		repo.RepoName = repoName[1] + "/" + repoName[2]


### PR DESCRIPTION
The DOM of the trending content on GitHub has now changed,
and it seems that `htmlquery.FindOne` is returning `nil`,
which is causing an error when trying to use the tool.

In this PR, the target acquisition element seems to have been replaced by `h2` as of November 2023, so propose to fix it to match this.
Also, added a process to return an error if the return value is `nil`.

In Japanese:
こんにちは！こちらのツールを拝見し、とても素敵で便利なツールだなと思いました。

現在GitHubの[トレンド](https://github.com/trending)内容のDOMが変更されており、
`htmlquery.FindOne`で`nil`が返されている為、ツールを利用しようとするとエラーとなっているようです。
このPRでは、対象の取得要素は2023年11月現在`h2`に置き換えられているように見受けられる為、これに合わせるよう修正します。
また、戻り値が`nil`だった場合にエラー返却を行う処理を追加しました。