### PR TITLE
fix: Correctly set repository URL and add test

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -167,7 +167,12 @@ func ParseRepos(r io.Reader) ([]Repository, error) {
 		}
 
 		hrefPath := htmlquery.SelectAttr(repoLinkNode, "href")
-		repo.Href = path.Join(githubURL, hrefPath)
+		href, err := url.JoinPath(githubURL, hrefPath)
+		if err != nil {
+			return nil, err
+		}
+
+		repo.Href = href
 		repoName := strings.Split(hrefPath, "/")
 		repo.RepoName = repoName[1] + "/" + repoName[2]
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright © 2022 Takafumi Umemoto <takafumi.umemoto@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd_test
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/nmemoto/gh-trending/cmd"
+)
+
+// Verify that the current Trends Page can properly fetch information
+func TestParseRepos(t *testing.T) {
+	// Check behavior in default state
+	u := &url.URL{
+		Scheme:   "https",
+		Host:     "github.com",
+		Path:     path.Join("trending", ""),
+		RawQuery: "",
+	}
+
+	resp, err := http.Get(u.String())
+	if err != nil {
+		t.Errorf("%s", err.Error())
+	}
+
+	defer resp.Body.Close()
+
+	var r io.Reader = resp.Body
+	repos, err := cmd.ParseRepos(r)
+	if err != nil {
+		t.Errorf("%s", err.Error())
+	}
+
+	// If "repos" is 0, it ends normally as "No Results".
+	if len(repos) == 0 {
+		return
+	}
+
+	for _, repo := range repos {
+		// Check href
+		url, err := url.Parse(repo.Href)
+		if err != nil {
+			t.Errorf("%s", err.Error())
+		}
+		if url.Scheme != "https" || url.Host != "github.com" {
+			t.Errorf("href is not valid: %s, expected, expect 'https' and 'github.com 'to be used for value", repo.Href)
+		}
+		// expected to be like "github.com","owner","repo"
+		if len(strings.Split(url.Path, "/")) != 3 {
+			t.Errorf("href is not valid: %s", repo.Href)
+		}
+
+		// Check repoName
+		if !regexp.MustCompile(`^[\w-]+/[\w-]+$`).MatchString(repo.RepoName) {
+			t.Errorf("repoName is not valid: %s, expected to be like owner/repo", repo.RepoName)
+		}
+		if !strings.Contains(repo.Href, repo.RepoName) {
+			t.Errorf("repoName should be included in href: %s, %s", repo.Href, repo.RepoName)
+		}
+
+		// TODO: Other repository members
+		// // Check starsInPeriod, expected to be like 1,234 stars today, or 1,234 stars this week etc...
+		// if repo.StarsInPeriod == "" {
+		// 	t.Errorf("%s, starsInPeriod is empty", repo.RepoName)
+		// }
+		// if !regexp.MustCompile(`^\d+ stars (today|this week|this month)$`).MatchString(repo.StarsInPeriod) {
+		// 	t.Errorf("%s, starsInPeriod is not valid: %s", repo.RepoName, repo.StarsInPeriod)
+		// }
+	}
+}


### PR DESCRIPTION
When `path.Join` is used for URL construction, the behavior observed is that the repo.Href is assigned a value like `https:/github.com/foo/bar`, which does not represent a valid URL (the scheme lacks a double slash).

In a Windows environment, despite assigning such incorrect values, the application operates normally, and the page can be accessed. However, this will be rectified by using `url.JoinPath()` to set the correct URL.

Additionally, using a simplified approach, tests have been implemented in the codebase to ensure that the minimum expected information, such as the repository URL and name, can be obtained.

Note:
Since it is assumed that DOM elements are simply extracted from the page structure, there may be cases where the information is not accurately obtained depending on the contents of the repository. While it would be ideal to handle such cases, the current implementation has been kept simple for basic validation.

In Japanese:
`path.Join`をURL作成に利用した際の挙動として`repo.Href`には`https:/github.com/foo/bar`のような値が代入されており、
正常なURLを示していません。（スキームの後がダブルスラッシュではない）

Windows環境下ではこのような誤った値を代入しても正常に動作し、ページを開けることを確認していますが、
`url.JoinPath()`を利用することで正しいURLを設定するように修正します。

また、簡易ではありますが、コードベース上で最低限期待した情報が取得できるよう、リポジトリのURLと名称をチェックするテストを追加しました。

補足:
単純にページ構造からDOM要素を取っていると思いますので、リポジトリの内容によっては正確には取れない場合が存在します。
こちらも対応できることが非常に理想的ではありますが、大凡使えると思いますのでとりあえず現状の実装で簡易にチェックできる程度に検証は留めました。